### PR TITLE
Correct comment block

### DIFF
--- a/styles.js
+++ b/styles.js
@@ -67,7 +67,7 @@ export function addExampleStyles() {
     display: block;
   }
 
-  // begin vp styles...
+  /* begin vp styles... */
 
   .vp-tabbed {
     overflow-x: hidden;


### PR DESCRIPTION
CSS comments use the syntax `/* */`. This seems to be the culprit of the failure in https://github.com/w3c/vc-json-schema/actions/runs/5904523609/job/16016782352?pr=205